### PR TITLE
Fix: Alembic setup failing due to reserved attribute name

### DIFF
--- a/app/api/routes/datasets.py
+++ b/app/api/routes/datasets.py
@@ -21,7 +21,7 @@ def create_dataset(
     try:
         service = DatasetService(db)
         db_dataset = service.create_dataset(dataset, MOCK_USER_ID)
-        return db_dataset
+        return DatasetResponse.from_orm_with_alias(db_dataset)
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -38,7 +38,7 @@ def get_datasets(
     """Get all datasets for the current user."""
     service = DatasetService(db)
     datasets = service.get_datasets(MOCK_USER_ID, skip=skip, limit=limit)
-    return datasets
+    return [DatasetResponse.from_orm_with_alias(d) for d in datasets]
 
 
 @router.get("/{dataset_id}", response_model=DatasetResponse)
@@ -56,4 +56,4 @@ def get_dataset(
             detail="Dataset not found"
         )
     
-    return dataset
+    return DatasetResponse.from_orm_with_alias(dataset)

--- a/app/api/routes/outputs.py
+++ b/app/api/routes/outputs.py
@@ -19,7 +19,7 @@ def create_output_dataset(
     try:
         service = DatasetService(db)
         db_output = service.create_output_dataset(dataset_id, output_dataset)
-        return db_output
+        return OutputDatasetResponse.from_orm_with_alias(db_output)
     except ValueError as e:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -49,7 +49,7 @@ def get_output_datasets(
         )
     
     output_datasets = service.get_output_datasets(dataset_id)
-    return output_datasets
+    return [OutputDatasetResponse.from_orm_with_alias(o) for o in output_datasets]
 
 
 @router.get("/{dataset_id}/outputs/{output_id}", response_model=OutputDatasetResponse)
@@ -74,4 +74,4 @@ def get_output_dataset(
             detail="Output dataset does not belong to the specified dataset"
         )
     
-    return output_dataset
+    return OutputDatasetResponse.from_orm_with_alias(output_dataset)

--- a/app/models/dataset.py
+++ b/app/models/dataset.py
@@ -13,4 +13,4 @@ class Dataset(Base):
     user_id = Column(UUID(as_uuid=True), nullable=False)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     inputs = Column(JSON, nullable=False)  # mapping inputId -> input_string
-    user_metadata = Column(JSON, default=dict)  # user-defined metadata
+    user_metadata = Column('metadata', JSON, default=dict)  # user-defined metadata

--- a/app/models/output.py
+++ b/app/models/output.py
@@ -14,7 +14,7 @@ class OutputDataset(Base):
     dataset_id = Column(UUID(as_uuid=True), ForeignKey("datasets.id"), nullable=False)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     outputs = Column(JSON, nullable=False)  # mapping (dataset_name, input_id) -> [output_strings]
-    user_metadata = Column(JSON, default=dict)
+    user_metadata = Column('metadata', JSON, default=dict)
     
     # Relationship
     dataset = relationship("Dataset", backref="output_datasets")

--- a/app/schemas/dataset.py
+++ b/app/schemas/dataset.py
@@ -17,6 +17,18 @@ class DatasetResponse(BaseModel):
     created_at: datetime
     inputs: Dict[str, str]
     metadata: Dict[str, Any]
+
+    @classmethod
+    def from_orm_with_alias(cls, obj: "Dataset"):
+        # Map ORM user_metadata -> API metadata
+        return cls(
+            id=obj.id,
+            name=obj.name,
+            user_id=obj.user_id,
+            created_at=obj.created_at,
+            inputs=obj.inputs,
+            metadata=getattr(obj, 'user_metadata', {}) or {}
+        )
     
     class Config:
         from_attributes = True

--- a/app/schemas/output.py
+++ b/app/schemas/output.py
@@ -17,6 +17,18 @@ class OutputDatasetResponse(BaseModel):
     created_at: datetime
     outputs: Dict[str, List[str]]
     metadata: Dict[str, Any]
+
+    @classmethod
+    def from_orm_with_alias(cls, obj: "OutputDataset"):
+        # Map ORM user_metadata -> API metadata
+        return cls(
+            id=obj.id,
+            name=obj.name,
+            dataset_id=obj.dataset_id,
+            created_at=obj.created_at,
+            outputs=obj.outputs,
+            metadata=getattr(obj, 'user_metadata', {}) or {}
+        )
     
     class Config:
         from_attributes = True

--- a/app/services/dataset_service.py
+++ b/app/services/dataset_service.py
@@ -17,7 +17,7 @@ class DatasetService:
             name=dataset_data.name,
             user_id=user_id,
             inputs=dataset_data.inputs,
-            metadata=dataset_data.metadata
+            user_metadata=dataset_data.metadata
         )
         self.db.add(db_dataset)
         self.db.commit()
@@ -57,7 +57,7 @@ class DatasetService:
             name=output_data.name,
             dataset_id=dataset_id,
             outputs=output_data.outputs,
-            metadata=output_data.metadata
+            user_metadata=output_data.metadata
         )
         self.db.add(db_output)
         self.db.commit()


### PR DESCRIPTION
Fix: Alembic setup failing due to reserved attribute name
Root cause: SQLAlchemy reserves the attribute name metadata on declarative models. Using it in the ORM class caused InvalidRequestError during Alembic env loading.

Changes applied
Models now use a safe attribute name user_metadata while mapping to the DB column 'metadata':
c:\Code\oedipus\app\models\dataset.py → user_metadata = Column('metadata', JSON, default=dict)
c:\Code\oedipus\app\models\output.py → user_metadata = Column('metadata', JSON, default=dict)
Service layer updated to set/read the right field:
c:\Code\oedipus\app\services\dataset_service.py
Create dataset uses user_metadata=dataset_data.metadata
Create output dataset uses user_metadata=output_data.metadata
API responses preserved as metadata by mapping:
c:\Code\oedipus\app\schemas\dataset.py → added DatasetResponse.from_orm_with_alias
c:\Code\oedipus\app\schemas\output.py → added OutputDatasetResponse.from_orm_with_alias
c:\Code\oedipus\app\api\routes\datasets.py and outputs.py now return those mapped responses.