### PR TITLE
Add Comparison demo page

### DIFF
--- a/alembic/versions/002_add_comparisons.py
+++ b/alembic/versions/002_add_comparisons.py
@@ -1,0 +1,37 @@
+"""Add comparisons table
+
+Revision ID: 002
+Revises: 001
+Create Date: 2025-08-27 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = '002'
+down_revision = '001'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'comparisons',
+        sa.Column('id', postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column('name', sa.String(), nullable=False),
+        sa.Column('dataset_id', postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column('output_dataset_ids', sa.JSON(), nullable=False),
+        sa.Column('alignment_key', sa.String(), nullable=False),
+        sa.Column('comparison_config', sa.JSON(), nullable=True),
+        sa.Column('alignment_stats', sa.JSON(), nullable=True),
+        sa.Column('status', sa.String(), nullable=False),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=True),
+        sa.ForeignKeyConstraint(['dataset_id'], ['datasets.id']),
+        sa.PrimaryKeyConstraint('id')
+    )
+
+
+def downgrade() -> None:
+    op.drop_table('comparisons')

--- a/app/api/main.py
+++ b/app/api/main.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from .routes import datasets, outputs, analysis
+from .routes import datasets, outputs, analysis, comparisons
 from ..core.database import engine, Base
 
 # Create database tables
@@ -28,6 +28,7 @@ app.add_middleware(
 app.include_router(datasets.router)
 app.include_router(outputs.router)
 app.include_router(analysis.router)
+app.include_router(comparisons.router)
 
 
 @app.get("/")

--- a/app/api/routes/comparisons.py
+++ b/app/api/routes/comparisons.py
@@ -1,0 +1,58 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+from typing import List
+import uuid
+from ...core.database import get_db
+from ...services.comparison_service import ComparisonService
+from ...schemas.comparison import ComparisonCreate, ComparisonResponse
+
+router = APIRouter(prefix="/api/v1/comparisons", tags=["comparisons"])
+
+
+@router.post("/create", response_model=ComparisonResponse, status_code=status.HTTP_201_CREATED)
+def create_comparison(
+    payload: ComparisonCreate,
+    db: Session = Depends(get_db)
+):
+    try:
+        service = ComparisonService(db)
+        comp = service.create_comparison(payload)
+        return comp  # Pydantic from_attributes handles ORM
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+    except Exception as e:
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e))
+
+
+@router.get("/", response_model=List[ComparisonResponse])
+def list_comparisons(
+    skip: int = 0,
+    limit: int = 100,
+    db: Session = Depends(get_db)
+):
+    service = ComparisonService(db)
+    return service.list_comparisons(skip=skip, limit=limit)
+
+
+@router.get("/{comparison_id}", response_model=ComparisonResponse)
+def get_comparison(
+    comparison_id: uuid.UUID,
+    db: Session = Depends(get_db)
+):
+    service = ComparisonService(db)
+    comp = service.get_comparison(comparison_id)
+    if not comp:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Comparison not found")
+    return comp
+
+
+@router.delete("/{comparison_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_comparison(
+    comparison_id: uuid.UUID,
+    db: Session = Depends(get_db)
+):
+    service = ComparisonService(db)
+    ok = service.delete_comparison(comparison_id)
+    if not ok:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Comparison not found")
+    return None

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -2,3 +2,4 @@
 from .dataset import Dataset  # noqa: F401
 from .output import OutputDataset  # noqa: F401
 from .analysis import AnalysisJob  # noqa: F401
+from .comparison import Comparison  # noqa: F401

--- a/app/models/comparison.py
+++ b/app/models/comparison.py
@@ -1,0 +1,25 @@
+from sqlalchemy import Column, String, DateTime, JSON, ForeignKey
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.sql import func
+import uuid
+from ..core.database import Base
+
+
+class Comparison(Base):
+    __tablename__ = "comparisons"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    name = Column(String, nullable=False)
+    # Parent input dataset for which outputs are compared
+    dataset_id = Column(UUID(as_uuid=True), ForeignKey("datasets.id"), nullable=False)
+
+    # Configuration
+    output_dataset_ids = Column(JSON, nullable=False)  # List[UUID] as JSON array
+    alignment_key = Column(String, nullable=False, default="input_id")
+    comparison_config = Column(JSON, default=dict)
+
+    # Results/validation
+    alignment_stats = Column(JSON, default=dict)
+    status = Column(String, nullable=False, default="created")  # created/running/completed/failed
+
+    created_at = Column(DateTime(timezone=True), server_default=func.now())

--- a/app/schemas/comparison.py
+++ b/app/schemas/comparison.py
@@ -1,0 +1,35 @@
+from pydantic import BaseModel, Field
+from typing import List, Dict, Any, Optional
+from datetime import datetime
+import uuid
+
+
+class ComparisonCreate(BaseModel):
+    name: str
+    dataset_id: uuid.UUID
+    output_dataset_ids: List[uuid.UUID] = Field(..., min_items=2, description="At least two output datasets to compare")
+    alignment_key: str = "input_id"
+    comparison_config: Optional[Dict[str, Any]] = {}
+
+
+class AlignmentStats(BaseModel):
+    total_inputs: int
+    datasets_included: int
+    matched_inputs: int
+    coverage_percentage: float
+    unmatched_inputs: Dict[str, List[str]]  # dataset_id -> list[input_id]
+
+
+class ComparisonResponse(BaseModel):
+    id: uuid.UUID
+    name: str
+    dataset_id: uuid.UUID
+    output_dataset_ids: List[uuid.UUID]
+    alignment_key: str
+    comparison_config: Dict[str, Any]
+    alignment_stats: Dict[str, Any]
+    status: str
+    created_at: datetime
+
+    class Config:
+        from_attributes = True

--- a/app/services/comparison_service.py
+++ b/app/services/comparison_service.py
@@ -1,0 +1,97 @@
+from sqlalchemy.orm import Session
+from typing import List, Dict, Any, Tuple
+import uuid
+from ..models.dataset import Dataset
+from ..models.output import OutputDataset
+from ..models.comparison import Comparison
+from ..schemas.comparison import ComparisonCreate
+
+
+class ComparisonService:
+    def __init__(self, db: Session):
+        self.db = db
+
+    def create_comparison(self, payload: ComparisonCreate) -> Comparison:
+        # Validate base dataset
+        dataset: Dataset | None = self.db.query(Dataset).filter(Dataset.id == payload.dataset_id).first()
+        if not dataset:
+            raise ValueError(f"Dataset {payload.dataset_id} not found")
+
+        # Validate output datasets
+        outputs: List[OutputDataset] = (
+            self.db.query(OutputDataset)
+            .filter(OutputDataset.id.in_(payload.output_dataset_ids))
+            .all()
+        )
+        if len(outputs) != len(set(payload.output_dataset_ids)):
+            found_ids = {str(o.id) for o in outputs}
+            missing = [str(i) for i in payload.output_dataset_ids if str(i) not in found_ids]
+            raise ValueError(f"Output datasets not found: {missing}")
+
+        # Ensure all outputs belong to the same input dataset
+        for o in outputs:
+            if o.dataset_id != payload.dataset_id:
+                raise ValueError("All output datasets must belong to the specified dataset")
+
+        # Basic alignment + validation
+        alignment_stats = self._compute_alignment_stats(dataset.inputs, outputs)
+
+        comp = Comparison(
+            name=payload.name,
+            dataset_id=payload.dataset_id,
+            output_dataset_ids=[str(i) for i in payload.output_dataset_ids],
+            alignment_key=payload.alignment_key,
+            comparison_config=payload.comparison_config or {},
+            alignment_stats=alignment_stats,
+            status="created",
+        )
+        self.db.add(comp)
+        self.db.commit()
+        self.db.refresh(comp)
+        return comp
+
+    def list_comparisons(self, skip: int = 0, limit: int = 100) -> List[Comparison]:
+        return (
+            self.db.query(Comparison)
+            .order_by(Comparison.created_at.desc())
+            .offset(skip)
+            .limit(limit)
+            .all()
+        )
+
+    def get_comparison(self, comparison_id: uuid.UUID) -> Comparison | None:
+        return self.db.query(Comparison).filter(Comparison.id == comparison_id).first()
+
+    def delete_comparison(self, comparison_id: uuid.UUID) -> bool:
+        comp = self.get_comparison(comparison_id)
+        if not comp:
+            return False
+        self.db.delete(comp)
+        self.db.commit()
+        return True
+
+    def _compute_alignment_stats(self, inputs: Dict[str, str], outputs: List[OutputDataset]) -> Dict[str, Any]:
+        input_keys = set(inputs.keys())
+        matched_by_dataset: Dict[str, int] = {}
+        unmatched_inputs: Dict[str, List[str]] = {}
+        matched_intersection = input_keys.copy()
+
+        for o in outputs:
+            keys = set((o.outputs or {}).keys())
+            matched = keys & input_keys
+            matched_by_dataset[str(o.id)] = len(matched)
+            unmatched_inputs[str(o.id)] = sorted(list(input_keys - keys))
+            matched_intersection &= matched
+
+        total_inputs = len(input_keys)
+        matched_inputs = len(matched_intersection)
+        coverage = (matched_inputs / total_inputs * 100.0) if total_inputs else 0.0
+
+        return {
+            "total_inputs": total_inputs,
+            "datasets_included": len(outputs),
+            "matched_inputs": matched_inputs,
+            "coverage_percentage": round(coverage, 2),
+            "matched_by_dataset": matched_by_dataset,
+            "unmatched_inputs": unmatched_inputs,
+        }

--- a/frontend/components/comparison.py
+++ b/frontend/components/comparison.py
@@ -1,0 +1,115 @@
+import streamlit as st
+import requests
+from typing import Optional, Dict, Any, List
+
+API_BASE_URL = "http://localhost:8000"
+
+
+def _list_datasets() -> List[Dict[str, Any]]:
+    try:
+        r = requests.get(f"{API_BASE_URL}/api/v1/datasets/")
+        r.raise_for_status()
+        return r.json()
+    except Exception as e:
+        st.error(f"Failed to fetch datasets: {e}")
+        return []
+
+
+def _list_outputs(dataset_id: str) -> List[Dict[str, Any]]:
+    try:
+        r = requests.get(f"{API_BASE_URL}/api/v1/datasets/{dataset_id}/outputs")
+        r.raise_for_status()
+        return r.json()
+    except Exception as e:
+        st.error(f"Failed to fetch output datasets: {e}")
+        return []
+
+
+def render_comparison_creator() -> Optional[str]:
+    """
+    Render a comparison creation UI:
+    - Select base input dataset
+    - Select 2+ output datasets belonging to it
+    - Enter a name and create the comparison
+    Shows alignment stats after creation.
+    """
+    st.header("🆚 Create Comparison")
+
+    # Step 1: Choose base dataset
+    datasets = _list_datasets()
+    if not datasets:
+        st.info("No datasets available. Upload inputs and outputs first.")
+        return None
+
+    ds_options = {f"{d['name']} ({d['id'][:8]}...)": d for d in datasets}
+    ds_label = st.selectbox("Base Input Dataset", options=list(ds_options.keys()))
+    selected_dataset = ds_options[ds_label]
+
+    # Step 2: Choose output datasets for comparison
+    outputs = _list_outputs(selected_dataset['id'])
+    if not outputs:
+        st.info("This dataset has no output datasets yet.")
+        return None
+
+    out_options = {f"{o['name']} ({o['id'][:8]}...)": o for o in outputs}
+    chosen_labels = st.multiselect(
+        "Select at least two output datasets to compare",
+        options=list(out_options.keys()),
+    )
+
+    comp_name = st.text_input("Comparison Name", placeholder="e.g., GPT-4 vs Claude 3 vs Llama 3")
+
+    col1, col2 = st.columns(2)
+    with col1:
+        create_clicked = st.button("Create Comparison", type="primary")
+    with col2:
+        st.caption("Tip: Ensure the selected outputs belong to the chosen input dataset.")
+
+    if create_clicked:
+        if not comp_name.strip():
+            st.error("Please enter a comparison name.")
+            return None
+        if len(chosen_labels) < 2:
+            st.error("Select at least two output datasets.")
+            return None
+
+        chosen_outputs = [out_options[lbl]['id'] for lbl in chosen_labels]
+        payload = {
+            "name": comp_name,
+            "dataset_id": selected_dataset['id'],
+            "output_dataset_ids": chosen_outputs,
+            "alignment_key": "input_id",
+            "comparison_config": {"min_aligned": 10},
+        }
+        try:
+            resp = requests.post(f"{API_BASE_URL}/api/v1/comparisons/create", json=payload)
+            if resp.status_code == 201:
+                data = resp.json()
+                st.success("Comparison created!")
+                st.json({"comparison_id": data["id"], "status": data.get("status", "created")})
+
+                # Alignment stats summary
+                stats = data.get("alignment_stats", {}) or {}
+                if stats:
+                    st.subheader("Alignment Summary")
+                    col_a, col_b, col_c, col_d = st.columns(4)
+                    col_a.metric("Total Inputs", stats.get("total_inputs", 0))
+                    col_b.metric("Datasets", stats.get("datasets_included", 0))
+                    col_c.metric("Matched Inputs", stats.get("matched_inputs", 0))
+                    col_d.metric("Coverage %", stats.get("coverage_percentage", 0.0))
+
+                    with st.expander("Details: Unmatched Inputs by Dataset"):
+                        st.json(stats.get("unmatched_inputs", {}))
+                return data["id"]
+            else:
+                try:
+                    err = resp.json()
+                except Exception:
+                    err = resp.text
+                st.error(f"Failed to create comparison: {err}")
+                return None
+        except Exception as e:
+            st.error(f"Request failed: {e}")
+            return None
+
+    return None

--- a/frontend/streamlit_app.py
+++ b/frontend/streamlit_app.py
@@ -59,7 +59,7 @@ st.markdown('<p class="subtitle">Observability & Analytics Infrastructure for AI
 st.sidebar.title("Navigation")
 page = st.sidebar.selectbox(
     "Choose a page:",
-    ["🏠 Home", "📊 Upload Data", "🔬 Analysis", "📈 Dashboard"]
+    ["🏠 Home", "📊 Upload Data", "🆚 Comparisons", "🔬 Analysis", "📈 Dashboard"]
 )
 
 # Sidebar: local mode toggle (optional)
@@ -248,6 +248,10 @@ elif page == "🔬 Analysis":
             results = submit_analysis(output_id)
             st.session_state.analysis_results = results
         render_analysis_dashboard(output_id)
+
+elif page == "🆚 Comparisons":
+    from components.comparison import render_comparison_creator
+    render_comparison_creator()
 
 elif page == "📈 Dashboard":
     st.header("📈 Analysis Dashboard")


### PR DESCRIPTION
Phase 1: Core Infrastructure — Implemented
What I added
Backend

Comparison model, schema, service, and API routes:
POST /api/v1/comparisons/create
GET /api/v1/comparisons/
GET /api/v1/comparisons/{comparison_id}
DELETE /api/v1/comparisons/{comparison_id}
Basic alignment/validation:
Ensures all output datasets belong to the selected input dataset
Computes matched input intersection, coverage %, unmatched inputs per output dataset
Migration: 002_add_comparisons.py
Frontend (Streamlit)

New page “🆚 Comparisons”
Comparison creator:
Select base input dataset and 2+ output datasets
Create comparison
Displays alignment stats summary and unmatched inputs breakdown
How to run
Apply DB migration:

If using Alembic:
Run: alembic upgrade head
Or rely on existing Base.metadata.create_all (will create missing tables if running without Alembic).
Start backend:

python scripts/start_backend.py
Start frontend:

python scripts/start_frontend.py
Go to “🆚 Comparisons” to create a comparison and see alignment stats.
Notes
Frontend relies on existing dataset and output upload (already present).
Alignment currently uses input_id keys intersection; more advanced alignment rules can be added in ComparisonService when needed.